### PR TITLE
build.sh: Multinode testnet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,8 @@
 
 set -eux
 
-OUTDIR="validator-sets"
+NETWORK_NAME="devnet-0"
+OUTDIR="validator-sets/$NETWORK_NAME"
 NUM_NODES=4
 
 git submodule update --init
@@ -27,20 +28,19 @@ cd -
 
 cd "$OUTDIR"
 
-# TODO
-## Remove all generated node.config.toml files.
-#find . -mindepth 2 -iname node.config.toml | xargs rm
-## Move all keys files to single top-level directory.
-#find . -mindepth 2 -iname '*.keys.toml' | xargs -I '{}' mv '{}' ./
-## Move all seed peers files to top-level directory.
-#find . -mindepth 2 -iname '*.seed_peers.config.toml' | xargs rm
-## Move all network peers files to top-level directory.
-#find . -mindepth 2 -iname '*.network_peers.config.toml' -exec mv -f {} ./network_peers.config.toml \;
-## Move all consensus peers files to top-level directory.
-#find . -mindepth 2 -iname 'consensus_peers.config.toml' -exec mv -f {} ./consensus_peers.config.toml \;
-## Move all genesis.blob files to top-level directory.
-#find . -mindepth 2 -iname 'genesis.blob' -exec mv -f {} ./genesis.blob \;
-## Delete all directories.
-#find . -mindepth 1 -type d | xargs rmdir
+# Remove all generated node.config.toml files.
+find . -mindepth 2 -iname node.config.toml | xargs rm
+# Move all keys files to single top-level directory.
+find . -mindepth 2 -iname '*.keys.toml' | xargs -I '{}' mv '{}' ./
+# Move all seed peers files to top-level directory.
+find . -mindepth 2 -iname '*.seed_peers.config.toml' | xargs rm
+# Move all network peers files to top-level directory.
+find . -mindepth 2 -iname '*.network_peers.config.toml' -exec mv -f {} ./network_peers.config.toml \;
+# Move all consensus peers files to top-level directory.
+find . -mindepth 2 -iname 'consensus_peers.config.toml' -exec mv -f {} ./consensus_peers.config.toml \;
+# Move all genesis.blob files to top-level directory.
+find . -mindepth 2 -iname 'genesis.blob' -exec mv -f {} ./genesis.blob \;
+# Delete all directories.
+find . -mindepth 1 -type d | xargs rmdir
 
 cd -


### PR DESCRIPTION
Pass the `-n` argument to libra-config to have it generate configurations for a multi-node testnet using the same approach as the upstream Libra `build.sh` from their Terraform automations.